### PR TITLE
Add minified build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 js/bundle.js
+js/bundle.map.json

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   "devDependencies": {
     "browserify": "~6.2.0",
     "envify": "~3.0.0",
+    "minifyify": "^7.0.3",
     "reactify": "^0.15",
     "watchify": "~2.1.0",
     "local-web-server": "0.5.20"
   },
   "scripts": {
+    "build": "browserify js/app.js -d -p [minifyify --map js/bundle.map.json --output js/bundle.map.json] > js/bundle.js",
     "start": "watchify -o js/bundle.js -v -d . | ws"
   },
   "repository": {


### PR DESCRIPTION
Very useful site!

This PR adds a npm-script to minify the JavaScript from 3MB to 250K. I first tried to use the site on a train with a bad wifi connection and it didn't load. I was also curious to see what a simple react+flux app compresses down to, so I forked. I've used `minifyify` so you still get source-maps on production, in case that's what you were after.

`npm run build`

Thanks again for making this site :)
