### PR TITLE
optimize TagLink borders responsiveness

### DIFF
--- a/js/components/TagList/Item.js
+++ b/js/components/TagList/Item.js
@@ -23,8 +23,10 @@ const TagLink = styled(Link)`
     cursor: pointer;
   }
 
-  &:nth-child(4n) {
-    border-right: none;
+  @media (min-width: ${colors.maxWidth}) {
+    &:nth-child(4n) {
+      border-right: none;
+    }
   }
 
   @media (max-width: ${colors.maxWidth}) {


### PR DESCRIPTION
Current implementation leads to borderless boxes on small screens on every second right-column box.
PR fixes this by applying a “mobile-first” min-width media query.