### PR TITLE
Add GH stars count to plugins

### DIFF
--- a/js/actions.js
+++ b/js/actions.js
@@ -17,7 +17,8 @@ export const loadPlugins = () => {
       .then(res => res.json())
       .then((data) => {
         dispatch(receiveLoadPluginsSuccess(data))
-      }).catch(() => {
+      }).catch((err) => {
+        console.error(err);
         dispatch(receiveLoadPluginsSuccess(plugins));
       });
   };

--- a/js/components/PluginList.js
+++ b/js/components/PluginList.js
@@ -28,6 +28,7 @@ const PluginList = ({ plugins, location, route }) => {
           key={name}
           description={plugin.description}
           url={plugin.url}
+          stars={plugin.stars}
         />
       );
     });

--- a/js/components/PluginListItem/Stars.js
+++ b/js/components/PluginListItem/Stars.js
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+import { colors } from '../../constants';
+
+export default styled.span`
+  float: right;
+  color: ${colors.textColor};
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 1em;
+  font-weight: 300;
+  font-size: 1.1em;
+  
+  &::before {
+    content: '★ '
+  }
+`;

--- a/js/components/PluginListItem/index.js
+++ b/js/components/PluginListItem/index.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
 
-import { colors } from '../../constants';
 import Wrapper from './Wrapper';
 import Name from './Name';
 import Description from './Description';
+import Stars from './Stars';
 
-const PluginListItem = ({ url, name, description }) => {
+const PluginListItem = ({ url, name, description, stars }) => {
   return (
     <Wrapper href={url}>
+      <Stars>{stars}</Stars>
       <Name>{name}</Name>
       <Description>{description}</Description>
     </Wrapper>

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
+    "cross-env": "^5.0.1",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.15.1"
   },
@@ -30,7 +31,7 @@
   },
   "scripts": {
     "dev": "webpack-dev-server -d --history-api-fallback --hot --inline --progress --colors --port 1234 --config ./webpack.config.js",
-    "build": "NODE_ENV=production webpack --progress --colors  --config ./webpack.production.config.js"
+    "build": "cross-env NODE_ENV=production webpack --progress --colors  --config ./webpack.production.config.js"
   },
   "author": "Max Stoiber",
   "license": "MIT"


### PR DESCRIPTION
Hi,

I noticed that the number of Github stars was available in the data but not displayed in the website. I think it is valuable information so I add it this way:

![image](https://user-images.githubusercontent.com/566536/26928835-de416e8a-4c57-11e7-9f30-1bacfb987f84.png)

Feel free to update the styles to your convenience of course